### PR TITLE
Search the whole navigation hierarchy for a FlipBoardNavigationController instance

### DIFF
--- a/Classes/FlipBoardNavigationController.m
+++ b/Classes/FlipBoardNavigationController.m
@@ -223,7 +223,7 @@ typedef enum {
 }
 
 - (BOOL) gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    return YES;
+    return NO;
 }
 
 #pragma mark - Handle Panning Activity

--- a/Classes/FlipBoardNavigationController.m
+++ b/Classes/FlipBoardNavigationController.m
@@ -328,18 +328,14 @@ typedef enum {
 
 - (FlipBoardNavigationController *)flipboardNavigationController
 {
-    
-    if([self.parentViewController isKindOfClass:[FlipBoardNavigationController class]]){
-        return (FlipBoardNavigationController*)self.parentViewController;
+    UIViewController *parentViewController = self.parentViewController;
+    while (parentViewController != nil) {
+        if([parentViewController isKindOfClass:[FlipBoardNavigationController class]]){
+            return (FlipBoardNavigationController *)parentViewController;
+        }
+        parentViewController = parentViewController.parentViewController;
     }
-    else if([self.parentViewController isKindOfClass:[UINavigationController class]] &&
-            [self.parentViewController.parentViewController isKindOfClass:[FlipBoardNavigationController class]]){
-        return (FlipBoardNavigationController*)[self.parentViewController parentViewController];
-    }
-    else{
-        return nil;
-    }
-    
+    return nil;
 }
 
 


### PR DESCRIPTION
In case of a (deeply) nested hierarchy, FlipBoardNavigationController is not always found. This change keeps on searching until it either finds a FlipBoardNavigationController or reaches the navigation hierarchy's root. I borrowed this implementation from mm_drawercontroller.
